### PR TITLE
Behave well when using mbsync to sync maildirs

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -25,6 +25,7 @@ from subprocess import check_call, CalledProcessError
 from .Database import Database
 from .utils import get_message_summary
 from datetime import date, datetime, timedelta
+import uuid
 
 
 class MailMover(Database):
@@ -72,7 +73,14 @@ class MailMover(Database):
                     if self.dry_run:
                         continue
                     try:
-                        shutil.copy2(fname, destination)
+                        shutil.copy2(fname, 
+                            os.path.join(
+                                destination,
+                                # construct a new filename, composed of a made-up ID and the flags part
+                                # of the original filename.
+                                str(uuid.uuid1()) + ':' + os.path.basename(fname).split(':')[-1]
+                            )
+                        )
                         to_delete_fnames.append(fname)
                     except shutil.Error as e:
                         # this is ugly, but shutil does not provide more

--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -101,3 +101,8 @@ def get_mail_move_age():
         max_age = settings.get(mail_mover_section, 'max_age')
     return max_age
 
+def get_mail_move_rename():
+    rename = False
+    if settings.has_option(mail_mover_section, 'rename'):
+        rename = settings.get(mail_mover_section, 'rename').lower() == 'true'
+    return rename

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -29,7 +29,7 @@ from afew.main import main as inner_main
 from afew.utils import filter_compat
 from afew.FilterRegistry import all_filters
 from afew.Settings import user_config_dir, get_filter_chain
-from afew.Settings import get_mail_move_rules, get_mail_move_age
+from afew.Settings import get_mail_move_rules, get_mail_move_age, get_mail_move_rename
 from afew.NotmuchSettings import read_notmuch_settings, get_notmuch_new_query
 
 option_parser = optparse.OptionParser(
@@ -183,6 +183,7 @@ def main():
     if options.move_mails:
         options.mail_move_rules = get_mail_move_rules()
         options.mail_move_age = get_mail_move_age()
+        options.mail_move_rename = get_mail_move_rename()
 
     with Database() as database:
         configured_filter_chain = get_filter_chain(database)

--- a/afew/main.py
+++ b/afew/main.py
@@ -79,7 +79,7 @@ def main(options, database, query_string):
             print('%s --> %s' % (message, category))
     elif options.move_mails:
         for maildir, rules in options.mail_move_rules.items():
-            mover = MailMover(options.mail_move_age, options.dry_run)
+            mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run)
             mover.move(maildir, rules)
             mover.close()
     else:


### PR DESCRIPTION
I use [mbsync](http://isync.sourceforge.net/mbsync.html) to sync my maildir with remote IMAP, and it has an odd behaviour where moving a mail from one maildir to another without changing its name breaks the sync state because the UID for the message is derived from the filename alone; it seems like this is a limitation of mbsync which is otherwise a good bit of software. 

These changes add an option `rename` to `MailMover` which makes it concoct a new filename when it moves mail to another maildir. A similar workaround exists in e.g. [mu4e](https://code.google.com/p/mu0/issues/detail?id=76).

I'm guessing most afew users are either using offlineimap or some other tool for producing their maildir which is why nobody else has encountered this problem before.