### PR TITLE
unfold env-vars when determining config path

### DIFF
--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -27,6 +27,7 @@ from afew.FilterRegistry import all_filters
 user_config_dir = os.path.join(os.environ.get('XDG_CONFIG_HOME',
                                               os.path.expanduser('~/.config')),
                                'afew')
+user_config_dir=os.path.expandvars(user_config_dir)
 
 settings = SafeConfigParser()
 # preserve the capitalization of the keys.


### PR DESCRIPTION
This fixes a strange issue (#100) that results in an empty
filter chain if afew is called by anacron.