### PR TITLE
make --enable-filters option work

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -196,8 +196,9 @@ def main():
                 sys.exit('Unknown filter(s) selected: %s' % (' '.join(
                     enabled_filters_set.difference(all_filters_set))))
 
-            options.enable_filters = [all_filters[
-                filter_name]() for filter_name in options.enable_filters]
+            options.enable_filters = [all_filters[filter_name](database)
+                                      for filter_name
+                                      in options.enable_filters]
         else:
             options.enable_filters = configured_filter_chain
 


### PR DESCRIPTION
Filter classes have a mandatory argument.  Trying to use the
--enable-filters would result in:

    TypeError: __init__() takes exactly 2 arguments (1 given)

Because the code did not pass a value for 'database'.