### PR TITLE
Implement archiving mails into folders

### DIFF
--- a/afew/MailArchiver.py
+++ b/afew/MailArchiver.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+
+#
+# Copyright (c) dtk <dtk@gmx.de>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import notmuch
+import logging
+import os, shutil
+import uuid
+from datetime import date, datetime, timedelta
+from subprocess import check_call, CalledProcessError
+from .Database import Database
+from .utils import get_message_summary
+
+
+class MailArchiver(Database):
+    """
+    Move mail files matching a given notmuch query into archive folders.
+    """
+
+    def __init__(self, max_age=0, rename=False, dry_run=False):
+        super(MailArchiver, self).__init__()
+        self.db = notmuch.Database(self.db_path)
+        self.query = "folder:{folder} AND {subquery}"
+        if max_age:
+            days = timedelta(int(max_age))
+            start = date.today() - days
+            now = datetime.now()
+            self.query += " AND {start}..{now}".format(start=start.strftime("%s"),
+                                                       now=now.strftime("%s"))
+        self.dry_run = dry_run
+        self.rename = rename
+
+    def get_new_name(self, fname, destination):
+        if self.rename:
+            return os.path.join(destination,
+                    str(uuid.uuid1()) + ":" + os.path.basename(fname).split(":")[-1])
+        else:
+            return destination
+
+    def move(self, maildir, rules):
+        logging.info("checking mails in '{}'".format(maildir))
+        to_delete_fnames = set()
+        for query in rules.keys():
+            main_query = self.query.format(folder=maildir, subquery=query)
+            logging.debug("query: {}".format(main_query))
+            messages = notmuch.Query(self.db, main_query).search_messages()
+            for message in messages:
+                # A single message (identified by Message-ID) can be in
+                # several places; only touch the one(s) in this maildir.
+                to_move_fnames = [name for name in message.get_filenames()
+                        if maildir in name]
+                if not to_move_fnames:
+                    continue
+                # TODO: For now only the message date is available to build
+                # the destination folder name, maybe other fields should be
+                # exposed as well.
+                dst_folder = rules[query].format(
+                        date=datetime.fromtimestamp(message.get_date()))
+                dst_folder = "{}/{}/cur".format(self.db_path, dst_folder)
+                self.__log_move_action(message, maildir, dst_folder, self.dry_run)
+                if self.dry_run:
+                    continue
+                if not os.path.isdir(dst_folder):
+                    logging.debug("creating directory '{}'".format(dst_folder))
+                    os.makedirs(dst_folder)
+                for fname in to_move_fnames:
+                    try:
+                        shutil.copy2(fname, self.get_new_name(fname, dst_folder))
+                        to_delete_fnames.add(fname)
+                    except shutil.SameFileError:
+                        pass
+                    except shutil.Error as e:
+                        if not str(e).endswith("already exists"):
+                            raise
+
+        # Remove mail from source location
+        [os.remove(fname) for fname in to_delete_fnames]
+
+        if not self.dry_run:
+            logging.info("updating database")
+            self.__update_db(maildir)
+        else:
+            logging.info("Would update database")
+
+    def __update_db(self, maildir):
+        try:
+            check_call(["notmuch", "new"])
+        except CalledProcessError as err:
+            logging.error("Could not update notmuch database " \
+                          "after syncing maildir '{}': {}".format(maildir, err))
+            raise SystemExit
+
+    @staticmethod
+    def __log_move_action(message, source, destination, dry_run):
+        if dry_run:
+            level = logging.INFO
+            prefix = "I would move mail"
+        else:
+            level = logging.DEBUG
+            prefix = "moving mail"
+        logging.log(level, prefix)
+        logging.log(level, "    {}".format(get_message_summary(message).encode("utf-8")))
+        logging.log(level, "from '{}' to '{}'".format(source, destination))

--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -39,13 +39,14 @@ settings.read(os.path.join(user_config_dir, 'config'))
 # All the values for keys listed here are interpreted as ;-delimited lists
 value_is_a_list = ['tags', 'tags_blacklist']
 mail_mover_section = 'MailMover'
+mail_archiver_section = "MailArchiver"
 
 section_re = re.compile(r'^(?P<name>[a-z_][a-z0-9_]*)(\((?P<parent_class>[a-z_][a-z0-9_]*)\)|\.(?P<index>\d+))?$', re.I)
 def get_filter_chain(database):
     filter_chain = []
 
     for section in settings.sections():
-        if section == 'global' or section == mail_mover_section:
+        if section == 'global' or section in (mail_mover_section, mail_archiver_section):
             continue
 
         match = section_re.match(section)
@@ -76,16 +77,15 @@ def get_filter_chain(database):
 
     return filter_chain
 
-def get_mail_move_rules():
+def get_mail_section_rules(section):
     rule_pattern = re.compile(r"'(.+?)':(\S+)")
-    if settings.has_option(mail_mover_section, 'folders'):
+    if settings.has_option(section, 'folders'):
         all_rules = collections.OrderedDict()
 
-        for folder in settings.get(mail_mover_section, 'folders').split():
-            if settings.has_option(mail_mover_section, folder):
+        for folder in settings.get(section, 'folders').split():
+            if settings.has_option(section, folder):
                 rules = collections.OrderedDict()
-                raw_rules = re.findall(rule_pattern,
-                                       settings.get(mail_mover_section, folder))
+                raw_rules = re.findall(rule_pattern, settings.get(section, folder))
                 for rule in raw_rules:
                     rules[rule[0]] = rule[1]
                 all_rules[folder] = rules
@@ -96,14 +96,14 @@ def get_mail_move_rules():
     else:
         raise NameError("No folders defined to move mails from.")
 
-def get_mail_move_age():
+def get_mail_section_age(section):
     max_age = 0
-    if settings.has_option(mail_mover_section, 'max_age'):
-        max_age = settings.get(mail_mover_section, 'max_age')
+    if settings.has_option(section, 'max_age'):
+        max_age = settings.get(section, 'max_age')
     return max_age
 
-def get_mail_move_rename():
+def get_mail_section_rename(section):
     rename = False
-    if settings.has_option(mail_mover_section, 'rename'):
-        rename = settings.get(mail_mover_section, 'rename').lower() == 'true'
+    if settings.has_option(section, 'rename'):
+        rename = settings.get(section, 'rename').lower() == 'true'
     return rename

--- a/afew/main.py
+++ b/afew/main.py
@@ -22,6 +22,7 @@ import sys
 
 from .DBACL import DBACL as Classifier
 from .MailMover import MailMover
+from .MailArchiver import MailArchiver
 from .utils import extract_mail_body
 
 try:
@@ -82,5 +83,10 @@ def main(options, database, query_string):
             mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run)
             mover.move(maildir, rules)
             mover.close()
+    elif options.archive_mails:
+        for maildir, rules in options.mail_archive_rules.items():
+            archiver = MailArchiver(options.mail_archive_age, options.mail_archive_rename, options.dry_run)
+            archiver.move(maildir, rules)
+            archiver.close()
     else:
         sys.exit('Weird... please file a bug containing your command line.')


### PR DESCRIPTION
This adds an operation which can be used to file (archive) messages into folders. The new `MailArchiver` class is actually quite similar to `MailMover`, with the (important) addition that the destination folder name is expanded for variables. Ccurrently only the message date is provided for expansion, which allows to configure it like this:

```
[MailArchiver]
folders = INBOX
INBOX = 'not tag:flagged and not tag:inbox and not tag:unread':Archives/{date.year}/{date.year}-{date.month:0>2d}
```

That will move seen and unflagged messages from `INBOX` into an archives subfolder which contains the date and month of the message in its name. This
creates a folder structure like this:

```
Archives/
  2015/
    2015-11/
    2015-12/
  2016/
    2016-01/
    2016-02/
    ...
```