### PR TITLE
Fix incorrect tagging syntax in filters.rst

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -116,12 +116,12 @@ Some examples are:
     [HeaderMatchingFilter.2]
     header = List-Id
     pattern = <(?P<list_id>.*)>
-    tags = +lists +{list_id}
+    tags = +lists;+{list_id}
 
     [HeaderMatchingFilter.3]
     header = X-Redmine-Project
     pattern = (?P<project>.*)
-    tags = +redmine +{project}
+    tags = +redmine;+{project}
 
 SpamFilter and ListMailsFilter are implemented using HeaderMatchingFilter, and are
 only slightly more complicated than the above examples.


### PR DESCRIPTION
Tag lists are semicolon separated, not space separated! I've been pulling my hair out for ages over this, wondering why my tagging was broken.